### PR TITLE
Add Android function isTouchExplorationEnabled for specific Talkback service checks

### DIFF
--- a/android/src/main/java/com/kentkart/checkaccessibility/RNReactNativeCheckAccessibilityModule.java
+++ b/android/src/main/java/com/kentkart/checkaccessibility/RNReactNativeCheckAccessibilityModule.java
@@ -37,6 +37,16 @@ public class RNReactNativeCheckAccessibilityModule extends ReactContextBaseJavaM
   }
 
   @ReactMethod
+  public void isTouchExplorationEnabled(Callback callback) {
+      final AccessibilityManager accessibilityManager = (AccessibilityManager) this.reactContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
+      if (accessibilityManager == null || !accessibilityManager.isEnabled() || !accessibilityManager.isTouchExplorationEnabled()) {
+          callback.invoke("0", null);
+          return;
+      }
+      callback.invoke("1", null);
+  }
+
+  @ReactMethod
   void announce(String message) {
       final AccessibilityManager accessibilityManager = (AccessibilityManager) this.reactContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
       if (accessibilityManager == null || !accessibilityManager.isEnabled()) {

--- a/android/src/main/java/com/kentkart/checkaccessibility/RNReactNativeCheckAccessibilityModule.java
+++ b/android/src/main/java/com/kentkart/checkaccessibility/RNReactNativeCheckAccessibilityModule.java
@@ -11,6 +11,7 @@ import android.view.accessibility.AccessibilityManager;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.Promise;
 
 public class RNReactNativeCheckAccessibilityModule extends ReactContextBaseJavaModule {
 
@@ -37,13 +38,17 @@ public class RNReactNativeCheckAccessibilityModule extends ReactContextBaseJavaM
   }
 
   @ReactMethod
-  public void isTouchExplorationEnabled(Callback callback) {
+  public void isVoiceOverRunning(Promise promise) {
+    try {
       final AccessibilityManager accessibilityManager = (AccessibilityManager) this.reactContext.getSystemService(Context.ACCESSIBILITY_SERVICE);
       if (accessibilityManager == null || !accessibilityManager.isEnabled() || !accessibilityManager.isTouchExplorationEnabled()) {
-          callback.invoke("0", null);
+          promise.resolve("0");
           return;
       }
-      callback.invoke("1", null);
+      promise.resolve("1"); 
+    } catch (Exception e) {
+      promise.reject("IS_VOICE_OVER_RUNNING_ERROR", e); 
+    }
   }
 
   @ReactMethod

--- a/index.js
+++ b/index.js
@@ -1,6 +1,34 @@
 
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const { RNReactNativeCheckAccessibility } = NativeModules;
+
+// export const isVoiceOverRunning = () => {
+//     return new Promise(function(resolve, reject) {
+//         if (Platform.OS === "android") {
+//             RNReactNativeCheckAccessibility.isTouchExplorationEnabled(
+//                 (result, error) => {
+//                     console.log("isTouchExplorationEnabled", { result, error });
+//                     if (!error) {
+//                         resolve(result === "1");
+//                     } else {
+//                         reject(error);
+//                     }
+//                 }
+//             );
+//         } else {
+//             RNReactNativeCheckAccessibility.isVoiceOverRunning(
+//                 (error, result) => {
+//                     console.log("isVoiceOverRunning", { error, result });
+//                     if (!error) {
+//                         resolve(result === "1");
+//                     } else {
+//                         reject(error);
+//                     }
+//                 }
+//             );
+//         }
+//     });
+// }
 
 export default RNReactNativeCheckAccessibility;

--- a/index.js
+++ b/index.js
@@ -3,32 +3,4 @@ import { NativeModules, Platform } from 'react-native';
 
 const { RNReactNativeCheckAccessibility } = NativeModules;
 
-// export const isVoiceOverRunning = () => {
-//     return new Promise(function(resolve, reject) {
-//         if (Platform.OS === "android") {
-//             RNReactNativeCheckAccessibility.isTouchExplorationEnabled(
-//                 (result, error) => {
-//                     console.log("isTouchExplorationEnabled", { result, error });
-//                     if (!error) {
-//                         resolve(result === "1");
-//                     } else {
-//                         reject(error);
-//                     }
-//                 }
-//             );
-//         } else {
-//             RNReactNativeCheckAccessibility.isVoiceOverRunning(
-//                 (error, result) => {
-//                     console.log("isVoiceOverRunning", { error, result });
-//                     if (!error) {
-//                         resolve(result === "1");
-//                     } else {
-//                         reject(error);
-//                     }
-//                 }
-//             );
-//         }
-//     });
-// }
-
 export default RNReactNativeCheckAccessibility;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 
-import { NativeModules, Platform } from 'react-native';
+import { NativeModules } from 'react-native';
 
 const { RNReactNativeCheckAccessibility } = NativeModules;
 

--- a/ios/RNReactNativeCheckAccessibility.m
+++ b/ios/RNReactNativeCheckAccessibility.m
@@ -13,6 +13,19 @@ RCT_EXPORT_METHOD(announce:(NSString *)message)
      UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, @"message");
 }
 
+RCT_EXPORT_METHOD(isVoiceOverRunning,
+    resolver:(RCTPromiseResolveBlock)resolve
+    rejecter:(RCTPromiseRejectBlock)reject)
+{
+    @try {
+        resolve(UIAccessibilityIsVoiceOverRunning() ? @"1" : @"0");
+    }
+    @catch(NSException *exception) {
+        NSError *error = [NSError errorWithDomain:@"com.kentkart.checkaccessibility" code:0 userInfo:@{@"Error reason": exception.reason}];
+        reject(@"error", @"isVoiceOverRunning threw exception", error);
+    }
+}
+
 - (NSDictionary *)constantsToExport
 {
     BOOL isVoiveOverRunning = (UIAccessibilityIsVoiceOverRunning() ? 1 : 0);
@@ -23,6 +36,11 @@ RCT_EXPORT_METHOD(announce:(NSString *)message)
     }
     
     return @{ @"isAccessibilityEnabled": @"1" };
+}
+
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
 }
 
 @end

--- a/ios/RNReactNativeCheckAccessibility.m
+++ b/ios/RNReactNativeCheckAccessibility.m
@@ -13,9 +13,7 @@ RCT_EXPORT_METHOD(announce:(NSString *)message)
      UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, @"message");
 }
 
-RCT_EXPORT_METHOD(isVoiceOverRunning,
-    resolver:(RCTPromiseResolveBlock)resolve
-    rejecter:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(isVoiceOverRunning:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
 {
     @try {
         resolve(UIAccessibilityIsVoiceOverRunning() ? @"1" : @"0");
@@ -28,9 +26,9 @@ RCT_EXPORT_METHOD(isVoiceOverRunning,
 
 - (NSDictionary *)constantsToExport
 {
-    BOOL isVoiveOverRunning = (UIAccessibilityIsVoiceOverRunning() ? 1 : 0);
+    BOOL isVoiceOverRunning = (UIAccessibilityIsVoiceOverRunning() ? 1 : 0);
     
-    if(!isVoiveOverRunning)
+    if(!isVoiceOverRunning)
     {
         return @{ @"isAccessibilityEnabled": @"0" };
     }


### PR DESCRIPTION
On Android, using `isAccessibilityEnabled` will currently callback "1" when _any_ accessibility service is enabled. Rather than changing this feature, I've added a similar ReactMethod `isTouchExplorationEnabled` which lets us check for the specific Talkback accessibility service. This is more consistent with the iOS function.