### PR TITLE
Initialize package variable

### DIFF
--- a/ios/RNReactNativeCheckAccessibility.podspec
+++ b/ios/RNReactNativeCheckAccessibility.podspec
@@ -1,3 +1,4 @@
+package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
 
 Pod::Spec.new do |s|
   s.name         = "RNReactNativeCheckAccessibility"


### PR DESCRIPTION
Package variable cannot be read in the podfile.spec file as it has not been initialized.

=> Initializing the package variable to the content of package.json file